### PR TITLE
Fix compatibility with older tesseract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,5 @@ thiserror = "1.0"
 image = "0.23.14"
 
 [features]
-default = ["full"]
-full = ["tesseract_5_2"]
+default = ["tesseract_5_2"]
 tesseract_5_2 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,8 @@ thiserror = "1.0"
 
 [dev-dependencies]
 image = "0.23.14"
+
+[features]
+default = ["full"]
+full = ["tesseract_5_2"]
+tesseract_5_2 = []

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This is designed to expose the C API of
 Adding value by deviating from the API is a non-goal. That is left to libraries
 that build on top of `tesseract-plumbing`.
 
+## Requirements/Features
+
+Requires Tesseract version `5.2.0` or newer by default. Use `--no-default-features` if using an older version.
+
 ## Motivation
 
 I'm a maintainer of both [leptess](https://crates.io/crates/leptess) and

--- a/src/tess_base_api.rs
+++ b/src/tess_base_api.rs
@@ -1,16 +1,19 @@
 extern crate tesseract_sys;
 extern crate thiserror;
 
+#[cfg(feature = "tesseract_5_2")]
+use self::tesseract_sys::TessBaseAPIInit5;
 use self::tesseract_sys::{
     TessBaseAPIAllWordConfidences, TessBaseAPICreate, TessBaseAPIDelete, TessBaseAPIGetAltoText,
     TessBaseAPIGetComponentImages, TessBaseAPIGetHOCRText, TessBaseAPIGetInputImage,
     TessBaseAPIGetLSTMBoxText, TessBaseAPIGetSourceYResolution, TessBaseAPIGetTsvText,
     TessBaseAPIGetUTF8Text, TessBaseAPIGetWordStrBoxText, TessBaseAPIInit2, TessBaseAPIInit3,
-    TessBaseAPIInit5, TessBaseAPIMeanTextConf, TessBaseAPIRecognize, TessBaseAPISetImage,
-    TessBaseAPISetImage2, TessBaseAPISetPageSegMode, TessBaseAPISetRectangle,
-    TessBaseAPISetSourceResolution, TessBaseAPISetVariable, TessDeleteIntArray, TessOcrEngineMode,
-    TessPageIteratorLevel, TessPageSegMode,
+    TessBaseAPIMeanTextConf, TessBaseAPIRecognize, TessBaseAPISetImage, TessBaseAPISetImage2,
+    TessBaseAPISetPageSegMode, TessBaseAPISetRectangle, TessBaseAPISetSourceResolution,
+    TessBaseAPISetVariable, TessDeleteIntArray, TessOcrEngineMode, TessPageIteratorLevel,
+    TessPageSegMode,
 };
+
 use self::thiserror::Error;
 use crate::Text;
 use leptonica_plumbing::Pix;
@@ -132,6 +135,7 @@ impl TessBaseApi {
         Self(unsafe { TessBaseAPICreate() })
     }
 
+    #[cfg(feature = "tesseract_5_2")]
     /// Wrapper for [`Init-1`]https://tesseract-ocr.github.io/tessapi/5.x/a02438.html#a2be07b4c9449b8cfc43e9c26ee623050
     pub fn init_1(
         &mut self,


### PR DESCRIPTION
closes #6 

Tesseract c-api introduced `TessBaseAPIInit5` only with version 5.2. In some older systems, this version is hard to come by. This PR introduces a feature that isolates uses of `TessBaseAPIInit5`. The feature `tesseract_5_2` is enabled by default to cause compatibility with previous versions.