### PR TITLE
Add ResultIterator wrapper, `Display` impl for Text, and `get_raw` for Tesseract.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod tess_base_api;
 mod text;
+mod result_iterator;
 
 use self::tesseract_sys::TessVersion;
 pub use leptonica_plumbing;
@@ -13,6 +14,7 @@ pub use tess_base_api::{
 };
 pub use tesseract_sys;
 pub use text::Text;
+pub use result_iterator::ResultIterator;
 
 /// Wrapper for [`Version`](https://tesseract-ocr.github.io/tessapi/5.x/a02438.html#a3785779c909fcdd77e24b340f5913e4b)
 ///

--- a/src/result_iterator.rs
+++ b/src/result_iterator.rs
@@ -1,0 +1,20 @@
+
+pub struct ResultIterator(*mut tesseract_sys::TessResultIterator);
+
+impl Drop for ResultIterator {
+    fn drop(&mut self) {
+        unsafe { tesseract_sys::TessResultIteratorDelete(self.0) }
+    }
+}
+
+impl AsRef<*mut tesseract_sys::TessResultIterator> for ResultIterator {
+    fn as_ref(&self) -> &*mut tesseract_sys::TessResultIterator {
+        &self.0
+    }
+}
+
+impl ResultIterator {
+    pub fn new(raw: *mut tesseract_sys::TessResultIterator) -> Self {
+        Self(raw)
+    }
+}

--- a/src/tess_base_api.rs
+++ b/src/tess_base_api.rs
@@ -135,6 +135,10 @@ impl TessBaseApi {
         Self(unsafe { TessBaseAPICreate() })
     }
 
+    pub fn get_raw(&self) -> *const tesseract_sys::TessBaseAPI {
+        self.0
+    }
+
     #[cfg(feature = "tesseract_5_2")]
     /// Wrapper for [`Init-1`]https://tesseract-ocr.github.io/tessapi/5.x/a02438.html#a2be07b4c9449b8cfc43e9c26ee623050
     pub fn init_1(

--- a/src/text.rs
+++ b/src/text.rs
@@ -3,9 +3,11 @@ extern crate tesseract_sys;
 use self::tesseract_sys::TessDeleteText;
 use std::convert::AsRef;
 use std::ffi::CStr;
+use std::fmt::Display;
 use std::os::raw::c_char;
 
 /// Wrapper around Tesseract's returned strings
+#[derive(Debug)]
 pub struct Text(*mut c_char);
 
 unsafe impl Send for Text {}
@@ -28,6 +30,25 @@ impl Text {
 
 impl AsRef<CStr> for Text {
     fn as_ref(&self) -> &CStr {
+        if self.0.is_null() {
+            // TODO: This is a dumb hack.
+            // Tesseract may choose to return a null pointer for no text for some invalid states.
+            // This breaks one of the invariants on `from_ptr` and is invalid,
+            // so we return a static string with no characters.
+            return unsafe { CStr::from_ptr("\0".as_ptr().cast()) };
+        }
         unsafe { CStr::from_ptr(self.0) }
+    }
+}
+
+impl Display for Text {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.as_ref()
+                .to_str()
+                .expect("Tesseract returned invalid UTF-8 str")
+        )
     }
 }


### PR DESCRIPTION
In my own experimentation I ended up running into some issues with null pointers being returned from `GetUTF8Text()` for Tesseract result iterators, and as a result I added a null check to the `AsRef` impl. 

I'm not entirely sure that there should be an AsRef implementation for it in the first place, however, as creating a `CStr` (currently) requires walking the entire string every time. While this isn't the most expensive thing in the world, it's not 0-cost and (probably) a bad idea to conflate, especially since it may be done repeatedly when using them as references instead of once.

In my opinion it should *probably* be changed to an `Into<CStr>` or similar.