### PR TITLE
Use the latest release version of leptonica plumbing which includes a critical fix on windows for leptonica sys crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["leptonica", "tesseract", "ocr", "image"]
 license = "MIT"
 [dependencies]
 tesseract-sys = "~0.6"
-leptonica-plumbing = "1.0"
+leptonica-plumbing = "~1.4"
 thiserror = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Use latest release version of leptonica plumbing which includes a critical fix for windows issue: https://github.com/ccouzens/leptonica-sys/pull/28