### PR TITLE
Implement result iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["leptonica", "tesseract", "ocr", "image"]
 license = "MIT"
 [dependencies]
-tesseract-sys = "~0.6"
+tesseract-sys = { git = "https://github.com/DavidVentura/tesseract-sys" }
 leptonica-plumbing = "1.0"
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["leptonica", "tesseract", "ocr", "image"]
 license = "MIT"
 [dependencies]
 tesseract-sys = { git = "https://github.com/DavidVentura/tesseract-sys" }
-leptonica-plumbing = "1.0"
+leptonica-plumbing = { git = "https://github.com/DavidVentura/leptonica-plumbing" }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
+mod result_iterator;
 mod tess_base_api;
 mod text;
 
 use self::tesseract_sys::TessVersion;
 pub use leptonica_plumbing;
 pub use leptonica_plumbing::leptonica_sys;
+pub use result_iterator::{BoundingRect, ResultIterator, ResultItem, ResultIteratorIter};
 use std::ffi::CStr;
 pub use tess_base_api::{
     TessBaseApi, TessBaseApiGetAltoTextError, TessBaseApiGetHocrTextError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod text;
 use self::tesseract_sys::TessVersion;
 pub use leptonica_plumbing;
 pub use leptonica_plumbing::leptonica_sys;
-pub use result_iterator::{BoundingRect, ResultIterator, ResultItem, ResultIteratorIter};
+pub use result_iterator::{BoundingRect, PageIteratorLevel, ResultIterator, ResultItem, ResultIteratorIter};
 use std::ffi::CStr;
 pub use tess_base_api::{
     TessBaseApi, TessBaseApiGetAltoTextError, TessBaseApiGetHocrTextError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@ mod text;
 use self::tesseract_sys::TessVersion;
 pub use leptonica_plumbing;
 pub use leptonica_plumbing::leptonica_sys;
-pub use result_iterator::{BoundingRect, PageIteratorLevel, ResultIterator, ResultItem, ResultIteratorIter};
+pub use result_iterator::{BoundingRect, ResultIterator, ResultItem, ResultIteratorIter};
+pub use tesseract_sys::PageIteratorLevel;
 use std::ffi::CStr;
 pub use tess_base_api::{
     TessBaseApi, TessBaseApiGetAltoTextError, TessBaseApiGetHocrTextError,

--- a/src/result_iterator.rs
+++ b/src/result_iterator.rs
@@ -1,25 +1,4 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PageIteratorLevel {
-    Block,
-    Para,
-    Textline,
-    Word,
-    Symbol,
-}
-
-impl PageIteratorLevel {
-    pub(crate) fn to_sys(self) -> tesseract_sys::TessPageIteratorLevel {
-        match self {
-            PageIteratorLevel::Block => tesseract_sys::TessPageIteratorLevel_RIL_BLOCK,
-            PageIteratorLevel::Para => tesseract_sys::TessPageIteratorLevel_RIL_PARA,
-            PageIteratorLevel::Textline => tesseract_sys::TessPageIteratorLevel_RIL_TEXTLINE,
-            PageIteratorLevel::Word => tesseract_sys::TessPageIteratorLevel_RIL_WORD,
-            PageIteratorLevel::Symbol => tesseract_sys::TessPageIteratorLevel_RIL_SYMBOL,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BoundingRect {
     pub left: i32,
     pub top: i32,

--- a/src/result_iterator.rs
+++ b/src/result_iterator.rs
@@ -1,0 +1,212 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BoundingRect {
+    pub left: i32,
+    pub top: i32,
+    pub right: i32,
+    pub bottom: i32,
+}
+
+#[derive(Debug)]
+pub struct ResultItem {
+    pub text: Option<crate::Text>,
+    pub confidence: f32,
+    pub bounding_rect: Option<BoundingRect>,
+}
+
+impl BoundingRect {
+    pub fn width(&self) -> i32 {
+        self.right - self.left
+    }
+
+    pub fn height(&self) -> i32 {
+        self.bottom - self.top
+    }
+}
+
+#[derive(Debug)]
+pub struct ResultIterator(*mut tesseract_sys::TessResultIterator);
+
+#[derive(Debug)]
+pub struct ResultIteratorIter<'a> {
+    iterator: &'a mut ResultIterator,
+    level: tesseract_sys::TessPageIteratorLevel,
+    first_iteration: bool,
+}
+
+impl Drop for ResultIterator {
+    fn drop(&mut self) {
+        unsafe { tesseract_sys::TessResultIteratorDelete(self.0) }
+    }
+}
+
+impl AsRef<*mut tesseract_sys::TessResultIterator> for ResultIterator {
+    fn as_ref(&self) -> &*mut tesseract_sys::TessResultIterator {
+        &self.0
+    }
+}
+
+impl ResultIterator {
+    pub fn new(raw: *mut tesseract_sys::TessResultIterator) -> Self {
+        Self(raw)
+    }
+
+    pub fn confidence(&self, level: tesseract_sys::TessPageIteratorLevel) -> f32 {
+        unsafe { tesseract_sys::TessResultIteratorConfidence(self.0, level) }
+    }
+
+    pub fn is_at_beginning_of(&self, level: tesseract_sys::TessPageIteratorLevel) -> bool {
+        unsafe {
+            let page_iter = tesseract_sys::TessResultIteratorGetPageIteratorConst(self.0);
+            tesseract_sys::TessPageIteratorIsAtBeginningOf(page_iter, level) != 0
+        }
+    }
+
+    pub fn is_at_final_element(
+        &self,
+        level: tesseract_sys::TessPageIteratorLevel,
+        element: tesseract_sys::TessPageIteratorLevel,
+    ) -> bool {
+        unsafe {
+            let page_iter = tesseract_sys::TessResultIteratorGetPageIteratorConst(self.0);
+            tesseract_sys::TessPageIteratorIsAtFinalElement(page_iter, level, element) != 0
+        }
+    }
+
+    pub fn get_bounding_rect(
+        &self,
+        level: tesseract_sys::TessPageIteratorLevel,
+    ) -> Option<BoundingRect> {
+        unsafe {
+            let page_iter = tesseract_sys::TessResultIteratorGetPageIteratorConst(self.0);
+            let mut left = 0i32;
+            let mut top = 0i32;
+            let mut right = 0i32;
+            let mut bottom = 0i32;
+
+            let success = tesseract_sys::TessPageIteratorBoundingBox(
+                page_iter,
+                level,
+                &mut left,
+                &mut top,
+                &mut right,
+                &mut bottom,
+            );
+
+            if success != 0 {
+                Some(BoundingRect {
+                    left,
+                    top,
+                    right,
+                    bottom,
+                })
+            } else {
+                None
+            }
+        }
+    }
+
+    pub fn next(&mut self, level: tesseract_sys::TessPageIteratorLevel) -> bool {
+        unsafe { tesseract_sys::TessResultIteratorNext(self.0, level) != 0 }
+    }
+
+    pub fn get_utf8_text(
+        &self,
+        level: tesseract_sys::TessPageIteratorLevel,
+    ) -> Option<crate::Text> {
+        unsafe {
+            let text_ptr = tesseract_sys::TessResultIteratorGetUTF8Text(self.0, level);
+            if text_ptr.is_null() {
+                None
+            } else {
+                Some(crate::Text::new(text_ptr))
+            }
+        }
+    }
+
+    pub fn iter_at_level(
+        &mut self,
+        level: tesseract_sys::TessPageIteratorLevel,
+    ) -> ResultIteratorIter<'_> {
+        ResultIteratorIter {
+            iterator: self,
+            level,
+            first_iteration: true,
+        }
+    }
+
+    pub fn words(&mut self) -> ResultIteratorIter<'_> {
+        self.iter_at_level(tesseract_sys::TessPageIteratorLevel_RIL_WORD)
+    }
+
+    pub fn symbols(&mut self) -> ResultIteratorIter<'_> {
+        self.iter_at_level(tesseract_sys::TessPageIteratorLevel_RIL_SYMBOL)
+    }
+
+    pub fn lines(&mut self) -> ResultIteratorIter<'_> {
+        self.iter_at_level(tesseract_sys::TessPageIteratorLevel_RIL_TEXTLINE)
+    }
+
+    pub fn paragraphs(&mut self) -> ResultIteratorIter<'_> {
+        self.iter_at_level(tesseract_sys::TessPageIteratorLevel_RIL_PARA)
+    }
+
+    pub fn blocks(&mut self) -> ResultIteratorIter<'_> {
+        self.iter_at_level(tesseract_sys::TessPageIteratorLevel_RIL_BLOCK)
+    }
+}
+
+impl<'a> ResultIteratorIter<'a> {
+    pub fn is_at_beginning_of(&self, level: tesseract_sys::TessPageIteratorLevel) -> bool {
+        self.iterator.is_at_beginning_of(level)
+    }
+
+    pub fn is_at_final_element(
+        &self,
+        level: tesseract_sys::TessPageIteratorLevel,
+        element: tesseract_sys::TessPageIteratorLevel,
+    ) -> bool {
+        self.iterator.is_at_final_element(level, element)
+    }
+
+    pub fn get_bounding_rect(
+        &self,
+        level: tesseract_sys::TessPageIteratorLevel,
+    ) -> Option<BoundingRect> {
+        self.iterator.get_bounding_rect(level)
+    }
+
+    pub fn confidence(&self, level: tesseract_sys::TessPageIteratorLevel) -> f32 {
+        self.iterator.confidence(level)
+    }
+
+    pub fn get_utf8_text(
+        &self,
+        level: tesseract_sys::TessPageIteratorLevel,
+    ) -> Option<crate::Text> {
+        self.iterator.get_utf8_text(level)
+    }
+}
+
+impl<'a> Iterator for ResultIteratorIter<'a> {
+    type Item = ResultItem;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.first_iteration {
+            if !self.iterator.next(self.level) {
+                return None;
+            }
+        } else {
+            self.first_iteration = false;
+        }
+
+        let text = self.iterator.get_utf8_text(self.level);
+        let confidence = self.iterator.confidence(self.level);
+        let bounding_rect = self.iterator.get_bounding_rect(self.level);
+
+        Some(ResultItem {
+            text,
+            confidence,
+            bounding_rect,
+        })
+    }
+}

--- a/src/result_iterator.rs
+++ b/src/result_iterator.rs
@@ -11,7 +11,7 @@ pub struct ResultItem {
     pub text: Option<crate::Text>,
     pub confidence: f32,
     pub bounding_rect: Option<BoundingRect>,
-    pub level: PageIteratorLevel,
+    pub level: tesseract_sys::PageIteratorLevel,
 }
 
 impl BoundingRect {
@@ -30,7 +30,7 @@ pub struct ResultIterator(*mut tesseract_sys::TessResultIterator);
 #[derive(Debug)]
 pub struct ResultIteratorIter<'a> {
     iterator: &'a mut ResultIterator,
-    level: PageIteratorLevel,
+    level: tesseract_sys::PageIteratorLevel,
     first_iteration: bool,
 }
 
@@ -51,31 +51,31 @@ impl ResultIterator {
         Self(raw)
     }
 
-    pub fn confidence(&self, level: PageIteratorLevel) -> f32 {
-        unsafe { tesseract_sys::TessResultIteratorConfidence(self.0, level.to_sys()) }
+    pub fn confidence(&self, level: tesseract_sys::PageIteratorLevel) -> f32 {
+        unsafe { tesseract_sys::TessResultIteratorConfidence(self.0, level as u32) }
     }
 
-    pub fn is_at_beginning_of(&self, level: PageIteratorLevel) -> bool {
+    pub fn is_at_beginning_of(&self, level: tesseract_sys::PageIteratorLevel) -> bool {
         unsafe {
             let page_iter = tesseract_sys::TessResultIteratorGetPageIteratorConst(self.0);
-            tesseract_sys::TessPageIteratorIsAtBeginningOf(page_iter, level.to_sys()) != 0
+            tesseract_sys::TessPageIteratorIsAtBeginningOf(page_iter, level as u32) != 0
         }
     }
 
     pub fn is_at_final_element(
         &self,
-        level: PageIteratorLevel,
-        element: PageIteratorLevel,
+        level: tesseract_sys::PageIteratorLevel,
+        element: tesseract_sys::PageIteratorLevel,
     ) -> bool {
         unsafe {
             let page_iter = tesseract_sys::TessResultIteratorGetPageIteratorConst(self.0);
-            tesseract_sys::TessPageIteratorIsAtFinalElement(page_iter, level.to_sys(), element.to_sys()) != 0
+            tesseract_sys::TessPageIteratorIsAtFinalElement(page_iter, level as u32, element as u32) != 0
         }
     }
 
     pub fn get_bounding_rect(
         &self,
-        level: PageIteratorLevel,
+        level: tesseract_sys::PageIteratorLevel,
     ) -> Option<BoundingRect> {
         unsafe {
             let page_iter = tesseract_sys::TessResultIteratorGetPageIteratorConst(self.0);
@@ -86,7 +86,7 @@ impl ResultIterator {
 
             let success = tesseract_sys::TessPageIteratorBoundingBox(
                 page_iter,
-                level.to_sys(),
+                level as u32,
                 &mut left,
                 &mut top,
                 &mut right,
@@ -106,16 +106,16 @@ impl ResultIterator {
         }
     }
 
-    pub fn next(&mut self, level: PageIteratorLevel) -> bool {
-        unsafe { tesseract_sys::TessResultIteratorNext(self.0, level.to_sys()) != 0 }
+    pub fn next(&mut self, level: tesseract_sys::PageIteratorLevel) -> bool {
+        unsafe { tesseract_sys::TessResultIteratorNext(self.0, level as u32) != 0 }
     }
 
     pub fn get_utf8_text(
         &self,
-        level: PageIteratorLevel,
+        level: tesseract_sys::PageIteratorLevel,
     ) -> Option<crate::Text> {
         unsafe {
-            let text_ptr = tesseract_sys::TessResultIteratorGetUTF8Text(self.0, level.to_sys());
+            let text_ptr = tesseract_sys::TessResultIteratorGetUTF8Text(self.0, level as u32);
             if text_ptr.is_null() {
                 None
             } else {
@@ -126,7 +126,7 @@ impl ResultIterator {
 
     pub fn iter_at_level(
         &mut self,
-        level: PageIteratorLevel,
+        level: tesseract_sys::PageIteratorLevel,
     ) -> ResultIteratorIter<'_> {
         ResultIteratorIter {
             iterator: self,
@@ -136,53 +136,53 @@ impl ResultIterator {
     }
 
     pub fn words(&mut self) -> ResultIteratorIter<'_> {
-        self.iter_at_level(PageIteratorLevel::Word)
+        self.iter_at_level(tesseract_sys::PageIteratorLevel::RIL_WORD)
     }
 
     pub fn symbols(&mut self) -> ResultIteratorIter<'_> {
-        self.iter_at_level(PageIteratorLevel::Symbol)
+        self.iter_at_level(tesseract_sys::PageIteratorLevel::RIL_SYMBOL)
     }
 
     pub fn lines(&mut self) -> ResultIteratorIter<'_> {
-        self.iter_at_level(PageIteratorLevel::Textline)
+        self.iter_at_level(tesseract_sys::PageIteratorLevel::RIL_TEXTLINE)
     }
 
     pub fn paragraphs(&mut self) -> ResultIteratorIter<'_> {
-        self.iter_at_level(PageIteratorLevel::Para)
+        self.iter_at_level(tesseract_sys::PageIteratorLevel::RIL_PARA)
     }
 
     pub fn blocks(&mut self) -> ResultIteratorIter<'_> {
-        self.iter_at_level(PageIteratorLevel::Block)
+        self.iter_at_level(tesseract_sys::PageIteratorLevel::RIL_BLOCK)
     }
 }
 
 impl<'a> ResultIteratorIter<'a> {
-    pub fn is_at_beginning_of(&self, level: PageIteratorLevel) -> bool {
+    pub fn is_at_beginning_of(&self, level: tesseract_sys::PageIteratorLevel) -> bool {
         self.iterator.is_at_beginning_of(level)
     }
 
     pub fn is_at_final_element(
         &self,
-        level: PageIteratorLevel,
-        element: PageIteratorLevel,
+        level: tesseract_sys::PageIteratorLevel,
+        element: tesseract_sys::PageIteratorLevel,
     ) -> bool {
         self.iterator.is_at_final_element(level, element)
     }
 
     pub fn get_bounding_rect(
         &self,
-        level: PageIteratorLevel,
+        level: tesseract_sys::PageIteratorLevel,
     ) -> Option<BoundingRect> {
         self.iterator.get_bounding_rect(level)
     }
 
-    pub fn confidence(&self, level: PageIteratorLevel) -> f32 {
+    pub fn confidence(&self, level: tesseract_sys::PageIteratorLevel) -> f32 {
         self.iterator.confidence(level)
     }
 
     pub fn get_utf8_text(
         &self,
-        level: PageIteratorLevel,
+        level: tesseract_sys::PageIteratorLevel,
     ) -> Option<crate::Text> {
         self.iterator.get_utf8_text(level)
     }

--- a/src/tess_base_api.rs
+++ b/src/tess_base_api.rs
@@ -6,7 +6,7 @@ use self::tesseract_sys::TessBaseAPIInit5;
 use self::tesseract_sys::{
     TessBaseAPIAllWordConfidences, TessBaseAPICreate, TessBaseAPIDelete, TessBaseAPIGetAltoText,
     TessBaseAPIGetComponentImages, TessBaseAPIGetHOCRText, TessBaseAPIGetInputImage,
-    TessBaseAPIGetLSTMBoxText, TessBaseAPIGetSourceYResolution, TessBaseAPIGetTsvText,
+    TessBaseAPIGetIterator, TessBaseAPIGetLSTMBoxText, TessBaseAPIGetSourceYResolution, TessBaseAPIGetTsvText,
     TessBaseAPIGetUTF8Text, TessBaseAPIGetWordStrBoxText, TessBaseAPIInit2, TessBaseAPIInit3,
     TessBaseAPIMeanTextConf, TessBaseAPIRecognize, TessBaseAPISetImage, TessBaseAPISetImage2,
     TessBaseAPISetPageSegMode, TessBaseAPISetRectangle, TessBaseAPISetSourceResolution,
@@ -476,6 +476,21 @@ impl TessBaseApi {
                     leptonica_plumbing::Boxa::new_from_pointer(ptr),
                 )
             })
+        }
+    }
+
+    /// Get a result iterator after performing OCR recognition
+    ///
+    /// Returns `None` if no recognition has been performed or if the iterator
+    /// cannot be created.
+    pub fn get_iterator(&mut self) -> Option<crate::ResultIterator> {
+        unsafe {
+            let iter_ptr = TessBaseAPIGetIterator(self.0);
+            if iter_ptr.is_null() {
+                None
+            } else {
+                Some(crate::ResultIterator::new(iter_ptr))
+            }
         }
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -31,3 +31,13 @@ impl AsRef<CStr> for Text {
         unsafe { CStr::from_ptr(self.0) }
     }
 }
+
+impl std::fmt::Debug for Text {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let c_str = self.as_ref();
+        match c_str.to_str() {
+            Ok(s) => write!(f, "Text({:?})", s),
+            Err(_) => write!(f, "Text(<invalid UTF-8>)"),
+        }
+    }
+}


### PR DESCRIPTION
Requires https://github.com/ccouzens/tesseract-sys/pull/31

This PR implements `ResultIterator` and the functions that I needed: is_at_beginning/end, bounding_rect, confidence.

I did not figure out a way of making the `Iterator` work well, as you need a mut borrow for the iterator, but also a regular borrow to check the properties of the text. 

In `tesseract-rs` code, I can run something like this:

```rust
    let mut result_iter = ocr.get_iterator().unwrap();
    loop {
        let text = result_iter.get_utf8_text(PageIteratorLevel::RIL_WORD);
        let bounding_rect = result_iter.get_bounding_rect(PageIteratorLevel::RIL_WORD);
        let is_at_beginning_of_para = result_iter.is_at_beginning_of(PageIteratorLevel::RIL_PARA);
        let end_para = result_iter
            .is_at_final_element(PageIteratorLevel::RIL_TEXTLINE, PageIteratorLevel::RIL_WORD);

        println!(
            "Text: {:?}, beg para: {}, end para: {}, box {:?}",
            text, is_at_beginning_of_para, end_para, bounding_rect,
        );

        if !result_iter.next(PageIteratorLevel::RIL_WORD) {
            break;
        }
    }
```

and get, for the provided image:

```
Text: Some(Text("Hundreds")), beg para: true, end para: false, box Some(BoundingRect { left: 5, top: 19, right: 237, bottom: 60 })
Text: Some(Text("of")), beg para: false, end para: false, box Some(BoundingRect { left: 256, top: 19, right: 306, bottom: 60 })
Text: Some(Text("companies")), beg para: false, end para: false, box Some(BoundingRect { left: 320, top: 17, right: 581, bottom: 70 })
Text: Some(Text("around")), beg para: false, end para: false, box Some(BoundingRect { left: 599, top: 19, right: 768, bottom: 60 })
Text: Some(Text("the")), beg para: false, end para: false, box Some(BoundingRect { left: 787, top: 19, right: 866, bottom: 60 })
Text: Some(Text("world")), beg para: false, end para: false, box Some(BoundingRect { left: 884, top: 19, right: 1016, bottom: 60 })
Text: Some(Text("are")), beg para: false, end para: false, box Some(BoundingRect { left: 1037, top: 30, right: 1111, bottom: 60 })
Text: Some(Text("using")), beg para: false, end para: false, box Some(BoundingRect { left: 1133, top: 17, right: 1259, bottom: 70 })
Text: Some(Text("Rust")), beg para: false, end para: false, box Some(BoundingRect { left: 1278, top: 22, right: 1381, bottom: 60 })
Text: Some(Text("in")), beg para: false, end para: false, box Some(BoundingRect { left: 1400, top: 17, right: 1438, bottom: 59 })
Text: Some(Text("production")), beg para: false, end para: false, box Some(BoundingRect { left: 1462, top: 17, right: 1724, bottom: 70 })
Text: Some(Text("today")), beg para: false, end para: false, box Some(BoundingRect { left: 1743, top: 19, right: 1880, bottom: 70 })
Text: Some(Text("for")), beg para: false, end para: false, box Some(BoundingRect { left: 1896, top: 19, right: 1964, bottom: 60 })
Text: Some(Text("fast,")), beg para: false, end para: false, box Some(BoundingRect { left: 1980, top: 19, right: 2081, bottom: 68 })
Text: Some(Text("low-")), beg para: false, end para: true, box Some(BoundingRect { left: 2103, top: 19, right: 2202, bottom: 60 })
Text: Some(Text("resource,")), beg para: false, end para: false, box Some(BoundingRect { left: 5, top: 111, right: 223, bottom: 149 })
Text: Some(Text("cross-platform")), beg para: false, end para: false, box Some(BoundingRect { left: 243, top: 100, right: 598, bottom: 151 })
Text: Some(Text("solutions.")), beg para: false, end para: false, box Some(BoundingRect { left: 619, top: 98, right: 855, bottom: 141 })
Text: Some(Text("Software")), beg para: false, end para: false, box Some(BoundingRect { left: 874, top: 100, right: 1086, bottom: 141 })
Text: Some(Text("you")), beg para: false, end para: false, box Some(BoundingRect { left: 1104, top: 111, right: 1187, bottom: 151 })
Text: Some(Text("know")), beg para: false, end para: false, box Some(BoundingRect { left: 1211, top: 100, right: 1335, bottom: 141 })
Text: Some(Text("and")), beg para: false, end para: false, box Some(BoundingRect { left: 1352, top: 100, right: 1438, bottom: 141 })
Text: Some(Text("love,")), beg para: false, end para: false, box Some(BoundingRect { left: 1462, top: 100, right: 1569, bottom: 149 })
Text: Some(Text("like")), beg para: false, end para: false, box Some(BoundingRect { left: 1591, top: 98, right: 1671, bottom: 141 })
Text: Some(Text("Firefox,")), beg para: false, end para: false, box Some(BoundingRect { left: 1694, top: 98, right: 1866, bottom: 149 })
Text: Some(Text("Dropbox,")), beg para: false, end para: false, box Some(BoundingRect { left: 1889, top: 100, right: 2101, bottom: 151 })
Text: Some(Text("and")), beg para: false, end para: true, box Some(BoundingRect { left: 2120, top: 100, right: 2206, bottom: 141 })
Text: Some(Text("Cloudflare,")), beg para: false, end para: false, box Some(BoundingRect { left: 3, top: 181, right: 261, bottom: 230 })
Text: Some(Text("uses")), beg para: false, end para: false, box Some(BoundingRect { left: 283, top: 192, right: 387, bottom: 222 })
Text: Some(Text("Rust.")), beg para: false, end para: false, box Some(BoundingRect { left: 408, top: 184, right: 522, bottom: 222 })
Text: Some(Text("From")), beg para: false, end para: false, box Some(BoundingRect { left: 542, top: 184, right: 660, bottom: 222 })
Text: Some(Text("startups")), beg para: false, end para: false, box Some(BoundingRect { left: 674, top: 185, right: 884, bottom: 233 })
Text: Some(Text("to")), beg para: false, end para: false, box Some(BoundingRect { left: 896, top: 185, right: 946, bottom: 222 })
Text: Some(Text("large")), beg para: false, end para: false, box Some(BoundingRect { left: 962, top: 180, right: 1086, bottom: 233 })
Text: Some(Text("corporations,")), beg para: false, end para: false, box Some(BoundingRect { left: 1100, top: 176, right: 1430, bottom: 233 })
Text: Some(Text("from")), beg para: false, end para: false, box Some(BoundingRect { left: 1443, top: 180, right: 1559, bottom: 222 })
Text: Some(Text("embedded")), beg para: false, end para: false, box Some(BoundingRect { left: 1574, top: 180, right: 1834, bottom: 222 })
Text: Some(Text("devices")), beg para: false, end para: false, box Some(BoundingRect { left: 1850, top: 176, right: 2033, bottom: 222 })
Text: Some(Text("to")), beg para: false, end para: true, box Some(BoundingRect { left: 2045, top: 185, right: 2095, bottom: 222 })
Text: Some(Text("scalable")), beg para: false, end para: false, box Some(BoundingRect { left: 0, top: 261, right: 204, bottom: 303 })
Text: Some(Text("web")), beg para: false, end para: false, box Some(BoundingRect { left: 217, top: 261, right: 318, bottom: 303 })
Text: Some(Text("services,")), beg para: false, end para: false, box Some(BoundingRect { left: 331, top: 257, right: 546, bottom: 312 })
Text: Some(Text("Rust")), beg para: false, end para: false, box Some(BoundingRect { left: 562, top: 264, right: 671, bottom: 303 })
Text: Some(Text("is")), beg para: false, end para: false, box Some(BoundingRect { left: 684, top: 257, right: 723, bottom: 303 })
Text: Some(Text("a")), beg para: false, end para: false, box Some(BoundingRect { left: 736, top: 272, right: 763, bottom: 303 })
Text: Some(Text("great")), beg para: false, end para: false, box Some(BoundingRect { left: 777, top: 266, right: 910, bottom: 314 })
Text: Some(Text("fit.")), beg para: false, end para: true, box Some(BoundingRect { left: 921, top: 261, right: 987, bottom: 303 })
Hundreds of companies around the world are using Rust in production today for fast, low-
resource, cross-platform solutions. Software you know and love, like Firefox, Dropbox, and
Cloudflare, uses Rust. From startups to large corporations, from embedded devices to
scalable web services, Rust is a great fit.
```